### PR TITLE
Improve the typesetting of the inserted #lang line to include module links

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -73,8 +73,17 @@
          (beside/baseline (tt ">") code #:sep (hspace 1))
          results)))))
   (cond [lang-line?
+         (define lang-line-port (open-input-string lang-line-ish))
+         (define lang-elements
+           (reverse
+            (let loop ([acc null])
+              (define input (read lang-line-port))
+              (if (eof-object? input) acc (loop (cons input acc))))))
          (nested #:style (if inset? 'code-inset #f)
-                 (codeblock0 #:context context (string-append "#lang " lang-line-ish))
+                 (hash-lang)
+                 (for/list ([element (in-list lang-elements)])
+                   (list (hspace 1)
+                         (racketmodname #,element)))
                  interaction)]
         [else
          (nested #:style (if inset? 'code-inset #f)


### PR DESCRIPTION
By default, `codeblock`'s linking is just okay. It doesn't link `#lang` (which is probably just an oversight which should be fixed), and it also doesn't link any subsequent identifiers as module names. This does.

I will note that this is not a very good solution. For one thing, if for some reason there are identifiers on the the `#lang` line that aren't module paths, this will try to link them as module paths, anyway. Also, this doesn't use the specific lang's reader for reading the elements on the `#lang` line.

I've also tried another approach which might work better, which is simply allowing an element to be passed to `#:lang-line?` instead. It will generate an element (based on the `codeblock` method) if `#:lang-line?` is `#t`, otherwise it will use the element provided. This would be less "magic", but it would be more general.

Let me know what you'd prefer.
