### PR TITLE
increase sandbox size so typed/racket evaluators can be created

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -16,7 +16,8 @@
 (define (make-code-eval #:lang lang)
   (parameterize ([sandbox-output 'string]
                  [sandbox-error-output 'string]
-                 [sandbox-propagate-exceptions #f])
+                 [sandbox-propagate-exceptions #f]
+                 [sandbox-memory-limit 100])
     (make-module-evaluator (string-append "#lang " lang "\n"))))
 
 ;; example use of code-examples:


### PR DESCRIPTION
I tried to create a code-examples block with `typed/racket` and it failed with an out of memory error (since the sandbox memory limit was too low). Using the same solution as described [here](https://github.com/racket/racket/issues/1719), I increased the sandbox memory size.