### PR TITLE
handle langs that don't use #%module-begin directly out of the reader

### DIFF
--- a/scribble-code-examples-lib/main.rkt
+++ b/scribble-code-examples-lib/main.rkt
@@ -138,6 +138,8 @@
 (define (split-module-syntax m)
   (syntax-parse m #:datum-literals (module #%module-begin)
     [(module _ m-lang:expr (#%module-begin stuff ...))
+     (values (syntax->datum #'m-lang) (syntax->list #'(stuff ...)))]
+    [(module _ m-lang:expr stuff ...)
      (values (syntax->datum #'m-lang) (syntax->list #'(stuff ...)))]))
 
 ;; source-location-strs : String Natural [Listof Stx] -> [Listof String]


### PR DESCRIPTION
My reader does not produce a #%module-begin. Rather, the first expansion step inserts it:

![image](https://user-images.githubusercontent.com/4582586/52157535-5a441e00-2655-11e9-9b1b-25560c9802bf.png)

It looks split-module-syntax is dealing with the result of the reader, and should handle this alternate form.